### PR TITLE
changed rails minimum version requirement to 4.0

### DIFF
--- a/realtime.gemspec
+++ b/realtime.gemspec
@@ -17,8 +17,8 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.rdoc"]
   s.test_files = Dir["test/**/*"]
 
-  s.add_dependency "rails", "~> 4.1.1"
-  
+  s.add_dependency "rails", ">= 4.0"
+
   #s.add_dependency "redis"
   #s.add_dependency "zmq"
   #s.add_dependency "em-zmq"


### PR DESCRIPTION
this will make realtime-rails compatible with rails 4.0
