### PR TITLE
Allow realtime_controller to receive *_action callback options

### DIFF
--- a/lib/realtime/realtime_controller.rb
+++ b/lib/realtime/realtime_controller.rb
@@ -4,15 +4,15 @@ module Realtime
 
 		module ClassMethods
 			def realtime_controller(options = nil)
-			 	before_filter :do_realtime_token
-			 	before_filter :do_realtime_user_id
-			 	before_filter :do_realtime_server_url
+			 	before_action :do_realtime_token
+			 	before_action :do_realtime_user_id
+			 	before_action :do_realtime_server_url
 			 	if options.nil?
-			 		after_filter :store_realtime_session_redis
+			 		after_action :store_realtime_session_redis
 			 	elsif options[:queue] == :redis
-			 		after_filter :store_realtime_session_redis
+			 		after_action :store_realtime_session_redis
 			 	elsif options[:queue] == :zmq
-			 		after_filter :store_realtime_session_zmq
+			 		after_action :store_realtime_session_zmq
 			 	end
 			end
 		end
@@ -43,9 +43,9 @@ module Realtime
 			stored_session_data = JSON.generate(session_data)
 
 			ZmqWrapper.store_session(
-				realtime_user_id, 
-				@realtime_token, 
-				stored_session_data, 
+				realtime_user_id,
+				@realtime_token,
+				stored_session_data,
 				86400
 			)
 		end
@@ -58,7 +58,7 @@ module Realtime
 			}
 
 			# todo: merge additional session data passed in
-			
+
 			stored_session_data = JSON.generate(session_data)
 
 			RedisWrapper.redis.hset(
@@ -66,7 +66,7 @@ module Realtime
 				@realtime_token,
 				stored_session_data,
 			)
-			
+
 			# expire this realtime session after one day.
 			RedisWrapper.redis.expire("rtSession-" + realtime_user_id.to_s, 86400)
 		end

--- a/lib/realtime/realtime_controller.rb
+++ b/lib/realtime/realtime_controller.rb
@@ -4,15 +4,14 @@ module Realtime
 
 		module ClassMethods
 			def realtime_controller(options = nil)
-			 	before_action :do_realtime_token
-			 	before_action :do_realtime_user_id
-			 	before_action :do_realtime_server_url
-			 	if options.nil?
-			 		after_action :store_realtime_session_redis
-			 	elsif options[:queue] == :redis
-			 		after_action :store_realtime_session_redis
-			 	elsif options[:queue] == :zmq
-			 		after_action :store_realtime_session_zmq
+                                queue = options.delete(:queue)
+			 	before_action :do_realtime_token, options
+			 	before_action :do_realtime_user_id, options
+			 	before_action :do_realtime_server_url, options
+			 	if queue.nil? || queue == :redis
+			 		after_action :store_realtime_session_redis, options
+			 	elsif queue == :zmq
+			 		after_action :store_realtime_session_zmq, options
 			 	end
 			end
 		end


### PR DESCRIPTION
Recently, I used this gem in a Rails 4 application, I'm using devise for authentication.

I want only logged in user's to be treated as a Realtime users, but for guests I do not want any thing to happen.

So, in `application.html.erb` I'll only add a condition when calling `realtime_support` 
```Ruby
<%= realtime_support(message_handler: true) if current_user.present? %>
```

But in `application_controller` there is no way to pass a condition to `do_realtime_*` and `store_realtime_session_*` callbacks.

That's why I'm making this pull request, one can use `realtim_controller` as following
```Ruby
realtime_controller queue: :redis, if: :user_signed_in?
realtime_controller if: :user_signed_in?
realtime_controller queue: :zmq, only: [:at, :specific, :actions]
```