### PR TITLE
Set default options to an empty hash

### DIFF
--- a/lib/realtime/realtime_controller.rb
+++ b/lib/realtime/realtime_controller.rb
@@ -3,7 +3,7 @@ module Realtime
 		extend ActiveSupport::Concern
 
 		module ClassMethods
-			def realtime_controller(options = nil)
+			def realtime_controller(options = {})
                                 queue = options.delete(:queue)
 			 	before_action :do_realtime_token, options
 			 	before_action :do_realtime_user_id, options


### PR DESCRIPTION
Just a small change to allow calling `realtime_controller` without any parameters

```Ruby
class ApplicationController < ActionController::Base
  ...
  realtime_controller
  ...
end
```

As calling it with default `nil` value will raise `NoMethodError` Exception because there is no method called `delete` for `nil` class.